### PR TITLE
Add Docker PostgreSQL for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-DATABASE_URL="postgresql://user:password@your-do-managed-db-host:25060/cartergrove?sslmode=require"
+# Local dev (matches docker-compose.yml)
+DATABASE_URL="postgresql://cartergrove:localdev@localhost:5434/cartergrove"
+# Production (DigitalOcean managed DB)
+# DATABASE_URL="postgresql://user:password@your-do-managed-db-host:25060/cartergrove?sslmode=require"
 AUTH_SECRET="run: npx auth secret"
 GITHUB_CLIENT_ID=""
 GITHUB_CLIENT_SECRET=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Personal website for Carter Grove — resume, portfolio, and blog.
 ## Tech Stack
 - Next.js 15 (App Router) + TypeScript
 - Tailwind CSS v4 + shadcn/ui (new-york style)
-- PostgreSQL via Prisma (DigitalOcean managed database)
+- PostgreSQL via Prisma (Docker for local dev, DigitalOcean managed for prod)
 - NextAuth.js v5 + GitHub OAuth (restricted to `grovecj`)
 - framer-motion for portfolio animations
 - next-themes for dark mode
@@ -15,14 +15,25 @@ Personal website for Carter Grove — resume, portfolio, and blog.
 - `src/app/` — App Router pages and API routes
 - `src/components/` — React components (ui/ for shadcn, layout/ for shared)
 - `src/lib/` — Utilities (prisma, auth, markdown)
-- `prisma/` — Schema and seed data
+- `prisma/` — Schema, config, and seed data
 - `terraform/` — Infrastructure as code
 - `nginx/` — Reverse proxy config
 
+## Local Development
+```sh
+npm run db:up        # Start PostgreSQL via Docker (port 5434)
+npm run db:push      # Sync Prisma schema to database
+npm run db:seed      # Seed with sample data
+npm run dev          # Start Next.js dev server
+```
+
 ## Commands
 - `npm run dev` — Start dev server
-- `npx prisma db push` — Sync schema to PostgreSQL
-- `npx prisma db seed` — Seed database
+- `npm run db:up` / `npm run db:down` — Start/stop Docker PostgreSQL
+- `npm run db:push` — Sync Prisma schema
+- `npm run db:seed` — Seed database
+- `npm run db:reset` — Wipe and re-seed database
+- `npm run db:studio` — Open Prisma Studio GUI
 - `npm run build` — Production build
 - `npm run lint` — ESLint
 
@@ -31,3 +42,5 @@ Personal website for Carter Grove — resume, portfolio, and blog.
 - JSON arrays in PostgreSQL stored as text strings, parse with `JSON.parse()`
 - All admin routes behind NextAuth session check
 - shadcn/ui components in `src/components/ui/`
+- Prisma 7: PrismaClient requires `@prisma/adapter-pg` with a `pg.Pool`
+- Prisma seed config lives in `prisma.config.ts`, not `package.json`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    ports:
+      - "5434:5432"
+    environment:
+      POSTGRES_USER: cartergrove
+      POSTGRES_PASSWORD: localdev
+      POSTGRES_DB: cartergrove
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "db:up": "docker compose up -d",
+    "db:down": "docker compose down",
+    "db:push": "npx prisma db push",
+    "db:seed": "npx prisma db seed",
+    "db:reset": "npx prisma db push --force-reset && npx prisma db seed",
+    "db:studio": "npx prisma studio",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
+    seed: "npx tsx prisma/seed.ts",
   },
   datasource: {
     url: process.env["DATABASE_URL"],


### PR DESCRIPTION
## Summary
- Adds `docker-compose.yml` with PostgreSQL 17 Alpine container (port 5434)
- Adds npm convenience scripts (`db:up`, `db:down`, `db:push`, `db:seed`, `db:reset`, `db:studio`)
- Moves Prisma seed config from `package.json` to `prisma.config.ts` per Prisma 7 convention
- Updates `.env.example` with local dev connection string

## Test plan
- [ ] `npm run db:up` starts the container
- [ ] `npm run db:push` syncs the schema
- [ ] `npm run db:seed` populates sample data
- [ ] `npm run dev` serves all pages with data from the local DB
- [ ] `npm run db:reset` wipes and re-seeds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)