### PR TITLE
Fix Terraform config and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grovecj

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,27 +47,20 @@ variable "domain" {
 }
 
 # --- GitHub Repository ---
+# The repo already exists at github.com/grovecj/cartergrove-me.
+# Use a data source to reference it without trying to create it.
 
-resource "github_repository" "site" {
-  name        = "cartergrove-me"
-  description = "Personal website — cartergrove.me"
-  visibility  = "public"
-
-  has_issues   = true
-  has_projects = false
-  has_wiki     = false
-
-  lifecycle {
-    prevent_destroy = true
-  }
+data "github_repository" "site" {
+  full_name = "grovecj/cartergrove-me"
 }
 
 resource "github_branch_protection" "main" {
-  repository_id = github_repository.site.node_id
+  repository_id = data.github_repository.site.node_id
   pattern       = "main"
 
   required_pull_request_reviews {
-    required_approving_review_count = 0
+    required_approving_review_count = 1
+    require_code_owner_reviews      = true
   }
 
   enforce_admins = false
@@ -144,21 +137,8 @@ resource "digitalocean_record" "a_www" {
   ttl    = 300
 }
 
-resource "digitalocean_record" "cname_gif" {
-  domain = digitalocean_domain.root.id
-  type   = "CNAME"
-  name   = "gif"
-  value  = "${var.domain}."
-  ttl    = 300
-}
-
-resource "digitalocean_record" "cname_stats" {
-  domain = digitalocean_domain.root.id
-  type   = "CNAME"
-  name   = "stats"
-  value  = "${var.domain}."
-  ttl    = 300
-}
+# NOTE: gif.cartergrove.me and stats.cartergrove.me DNS records
+# are managed by their respective project repositories.
 
 # --- Outputs ---
 


### PR DESCRIPTION
## Summary
- Replace `github_repository` resource with data source (repo already exists)
- Add `github_branch_protection` on `main` requiring 1 approving review + code owner approval
- Remove `gif` and `stats` subdomain CNAME records (managed by their respective repos)
- Add `.github/CODEOWNERS` assigning `@grovecj` as owner of all files

## Test plan
- [ ] `terraform plan` shows no attempt to create a new repo
- [ ] `terraform plan` shows branch protection rule being created
- [ ] `terraform plan` does not include `cname_gif` or `cname_stats` records
- [ ] CODEOWNERS file is picked up by GitHub on PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)