### PR TITLE
Fix Terraform for existing DO resources

### DIFF
--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,4 +1,4 @@
 do_token              = "your-digitalocean-api-token"
 github_token          = "your-github-personal-access-token"
-ssh_key_fingerprint   = "your-ssh-key-fingerprint"
+ssh_key_name          = "your-ssh-key-name-in-digitalocean"
 domain                = "cartergrove.me"


### PR DESCRIPTION
## Summary
Fixes two `terraform apply` errors:

- **Domain already exists**: Changed `digitalocean_domain.root` from a `resource` to a `data` source since `cartergrove.me` is already registered in DigitalOcean
- **Invalid SSH key identifier**: DO API rejects SHA256 fingerprints for droplet creation. Replaced `ssh_key_fingerprint` variable with `ssh_key_name` and a `digitalocean_ssh_key` data source that looks up the key by name and passes the correct ID

## Test plan
- [ ] Update `terraform.tfvars` to use `ssh_key_name` instead of `ssh_key_fingerprint`
- [ ] `terraform plan` succeeds without domain or SSH key errors
- [ ] `terraform apply` creates the droplet and DNS records

🤖 Generated with [Claude Code](https://claude.com/claude-code)