### PR TITLE
Add CI/CD deployment pipeline and server bootstrap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
             cd /opt/cartergrove-me
-            npm ci --production
+            npm ci --omit=dev
             npx prisma generate
+            npx prisma db push --skip-generate
             pm2 restart cartergrove-me || pm2 start npm --name cartergrove-me -- start
+            pm2 save

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# One-time setup for a fresh Ubuntu 24.04 droplet.
+# Run as root: bash scripts/server-setup.sh
+set -euo pipefail
+
+DOMAIN="cartergrove.me"
+APP_DIR="/opt/cartergrove-me"
+DEPLOY_USER="deploy"
+
+echo "==> Creating deploy user"
+id -u "$DEPLOY_USER" &>/dev/null || adduser --disabled-password --gecos "" "$DEPLOY_USER"
+mkdir -p /home/$DEPLOY_USER/.ssh
+cp /root/.ssh/authorized_keys /home/$DEPLOY_USER/.ssh/authorized_keys
+chown -R $DEPLOY_USER:$DEPLOY_USER /home/$DEPLOY_USER/.ssh
+chmod 700 /home/$DEPLOY_USER/.ssh
+chmod 600 /home/$DEPLOY_USER/.ssh/authorized_keys
+
+echo "==> Installing Node.js 20"
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt-get install -y nodejs
+
+echo "==> Installing pm2"
+npm install -g pm2
+pm2 startup systemd -u $DEPLOY_USER --hp /home/$DEPLOY_USER
+
+echo "==> Installing nginx"
+apt-get install -y nginx
+
+echo "==> Installing certbot"
+apt-get install -y certbot python3-certbot-nginx
+
+echo "==> Creating app directory"
+mkdir -p "$APP_DIR"
+chown $DEPLOY_USER:$DEPLOY_USER "$APP_DIR"
+
+echo "==> Copying nginx config"
+cp "$APP_DIR/nginx/cartergrove.me.conf" /etc/nginx/sites-available/cartergrove.me.conf 2>/dev/null || echo "  (nginx config will be copied after first deploy)"
+ln -sf /etc/nginx/sites-available/cartergrove.me.conf /etc/nginx/sites-enabled/
+rm -f /etc/nginx/sites-enabled/default
+
+echo "==> Obtaining SSL certificate"
+certbot certonly --nginx -d "$DOMAIN" -d "www.$DOMAIN" --non-interactive --agree-tos --email "carter@cartergrove.me" || echo "  (SSL will be configured after DNS propagates)"
+
+echo "==> Reloading nginx"
+nginx -t && systemctl reload nginx
+
+echo "==> Done! Next steps:"
+echo "  1. Create /opt/cartergrove-me/.env with production DATABASE_URL, AUTH_SECRET, etc."
+echo "  2. Push to main to trigger the first GitHub Actions deploy."
+echo "  3. After first deploy: cp $APP_DIR/nginx/cartergrove.me.conf /etc/nginx/sites-available/ && nginx -t && systemctl reload nginx"


### PR DESCRIPTION
## Summary
- Add `scripts/server-setup.sh` — one-time bootstrap for a fresh Ubuntu 24.04 droplet (creates deploy user, installs Node.js 20, pm2, nginx, certbot)
- Improve `.github/workflows/deploy.yml`:
  - Run `prisma db push` on deploy to sync schema changes automatically
  - Run `pm2 save` to persist the process list across server reboots
  - Fix deprecated `npm ci --production` → `npm ci --omit=dev`

## Deployment Steps (after merge)

### 1. Add GitHub Secrets
Go to **Settings → Secrets and variables → Actions** and add:
- `DROPLET_IP` — the droplet's public IPv4 address (from `terraform output droplet_ip`)
- `DEPLOY_SSH_KEY` — private SSH key for the `deploy` user
- `DATABASE_URL` — production PostgreSQL connection string

### 2. Bootstrap the Droplet
```bash
ssh root@<DROPLET_IP>
git clone https://github.com/grovecj/cartergrove-me.git /tmp/cartergrove-me
bash /tmp/cartergrove-me/scripts/server-setup.sh
```

### 3. Create Production .env
```bash
ssh deploy@<DROPLET_IP>
cat > /opt/cartergrove-me/.env << 'EOF'
DATABASE_URL="postgresql://..."
AUTH_SECRET="<generate with: openssl rand -base64 32>"
GITHUB_ID="<oauth app client id>"
GITHUB_SECRET="<oauth app client secret>"
NEXTAUTH_URL="https://cartergrove.me"
EOF
```

### 4. Trigger First Deploy
Push to main (merging this PR will do it). The GitHub Action will build, rsync, and pm2 start.

### 5. Finalize nginx + SSL
After first deploy lands on the droplet:
```bash
ssh root@<DROPLET_IP>
cp /opt/cartergrove-me/nginx/cartergrove.me.conf /etc/nginx/sites-available/
nginx -t && systemctl reload nginx
certbot certonly --nginx -d cartergrove.me -d www.cartergrove.me
```

## Test plan
- [ ] `scripts/server-setup.sh` runs cleanly on a fresh Ubuntu 24.04 droplet
- [ ] GitHub Action builds and deploys successfully after secrets are configured
- [ ] Site loads at https://cartergrove.me after nginx + SSL setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)