### PR TITLE
Fix deploy: build on server to resolve Prisma runtime error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,44 +5,40 @@ on:
     branches: [main]
 
 jobs:
-  build-and-deploy:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - run: npm ci
-
-      - run: npx prisma generate
-
-      - run: npm run build
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-
-      - name: Deploy to Droplet
+      - name: Deploy source to Droplet
         uses: burnett01/rsync-deployments@6.0.0
         with:
-          switches: -avz --delete --exclude='.env' --exclude='node_modules' --exclude='.next/cache'
+          switches: -avz --delete --exclude='.env' --exclude='node_modules' --exclude='.next'
           path: ./
           remote_path: /opt/cartergrove-me/
           remote_host: ${{ secrets.DROPLET_IP }}
           remote_user: deploy
           remote_key: ${{ secrets.DEPLOY_SSH_KEY }}
 
-      - name: Install & Restart
+      - name: Build & Restart
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.DROPLET_IP }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 10m
           script: |
             cd /opt/cartergrove-me
-            npm ci --omit=dev
+            cat > .env <<'DOTENV'
+            DATABASE_URL="${{ secrets.DATABASE_URL }}"
+            AUTH_SECRET="${{ secrets.AUTH_SECRET }}"
+            OAUTH_GITHUB_CLIENT_ID="${{ secrets.OAUTH_GITHUB_CLIENT_ID }}"
+            OAUTH_GITHUB_CLIENT_SECRET="${{ secrets.OAUTH_GITHUB_CLIENT_SECRET }}"
+            NEXTAUTH_URL="https://cartergrove.me"
+            DOTENV
+            npm ci
             npx prisma generate
             npx prisma db push --skip-generate
+            npm run build
             pm2 restart cartergrove-me || pm2 start npm --name cartergrove-me -- start
             pm2 save


### PR DESCRIPTION
## Summary
- Build on the droplet instead of CI to fix `Cannot find module '@prisma/client-{hash}/runtime/client'` error caused by Turbopack embedding hashed Prisma runtime paths that don't match when node_modules is reinstalled on the server
- Write `.env` from GitHub Actions secrets during deploy so all env vars (DATABASE_URL, AUTH_SECRET, OAuth credentials, NEXTAUTH_URL) are available for both build and runtime
- Use full `npm ci` (not `--omit=dev`) since the build needs devDependencies

## Test plan
- [ ] Deploy completes successfully
- [ ] All routes return 200 (not 500)
- [ ] Admin login via GitHub OAuth works on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)">
</invoke>