### PR TITLE
Fix deploy: build on server for Prisma runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,44 +5,40 @@ on:
     branches: [main]
 
 jobs:
-  build-and-deploy:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - run: npm ci
-
-      - run: npx prisma generate
-
-      - run: npm run build
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-
-      - name: Deploy to Droplet
+      - name: Deploy source to Droplet
         uses: burnett01/rsync-deployments@6.0.0
         with:
-          switches: -avz --delete --exclude='.env' --exclude='node_modules' --exclude='.next/cache'
+          switches: -avz --delete --exclude='.env' --exclude='node_modules' --exclude='.next'
           path: ./
           remote_path: /opt/cartergrove-me/
           remote_host: ${{ secrets.DROPLET_IP }}
           remote_user: deploy
           remote_key: ${{ secrets.DEPLOY_SSH_KEY }}
 
-      - name: Install & Restart
+      - name: Build & Restart
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.DROPLET_IP }}
           username: deploy
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 10m
           script: |
             cd /opt/cartergrove-me
-            npm ci --omit=dev
+            cat > .env <<'DOTENV'
+            DATABASE_URL="${{ secrets.DATABASE_URL }}"
+            AUTH_SECRET="${{ secrets.AUTH_SECRET }}"
+            OAUTH_GITHUB_CLIENT_ID="${{ secrets.OAUTH_GITHUB_CLIENT_ID }}"
+            OAUTH_GITHUB_CLIENT_SECRET="${{ secrets.OAUTH_GITHUB_CLIENT_SECRET }}"
+            NEXTAUTH_URL="https://cartergrove.me"
+            DOTENV
+            npm ci
             npx prisma generate
             npx prisma db push --skip-generate
+            npm run build
             pm2 restart cartergrove-me || pm2 start npm --name cartergrove-me -- start
             pm2 save


### PR DESCRIPTION
## Summary
- Build the Next.js app on the droplet instead of in CI to fix Prisma client hash mismatch
- Turbopack embeds hashed Prisma runtime paths at build time — building in CI and rsyncing `.next` to the server caused module resolution errors because the server's `node_modules` has different hashes
- Also writes `.env` from GitHub Actions secrets during deploy so the build has access to `DATABASE_URL`

**This fixes the broken `/resume` (and any other Prisma-dependent page) in production** — the RSC stream aborts mid-flight when Prisma throws, causing `TypeError: Error in input stream` on the client.

## Test plan
- [ ] Merge and confirm the deploy workflow succeeds in GitHub Actions
- [ ] Verify `/resume` loads correctly on https://cartergrove.me
- [ ] Verify `/portfolio` and `/blog` also load (they also use Prisma)

🤖 Generated with [Claude Code](https://claude.com/claude-code)