### PR TITLE
Fix pg Pool: add SSL support and connection timeout

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -7,7 +7,13 @@ const globalForPrisma = globalThis as unknown as {
 };
 
 function createPrismaClient() {
-  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    connectionTimeoutMillis: 5000,
+    ssl: process.env.DATABASE_URL?.includes("sslmode=require")
+      ? { rejectUnauthorized: false }
+      : undefined,
+  });
   const adapter = new PrismaPg(pool);
   return new PrismaClient({ adapter });
 }


### PR DESCRIPTION
## Summary
- Explicitly pass `ssl: { rejectUnauthorized: false }` to the `pg.Pool` when the connection string includes `sslmode=require` — DigitalOcean managed PostgreSQL requires SSL but `pg` doesn't properly negotiate it from just the query parameter
- Add `connectionTimeoutMillis: 5000` so failed connections error fast instead of hanging until nginx returns a 504

**Fixes the 504 gateway timeout on `/api/banners` and the hanging RSC navigation to database-backed pages like `/resume`.**

## Test plan
- [ ] Merge and confirm deploy succeeds
- [ ] Verify `/resume` loads on https://cartergrove.me (no more 504s or "Error in input stream")
- [ ] Verify `/api/banners` returns a response (not 504)

🤖 Generated with [Claude Code](https://claude.com/claude-code)