### PR TITLE
Fix seed script SSL for managed PostgreSQL

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,7 +4,12 @@ import { PrismaPg } from "@prisma/adapter-pg";
 
 import { Pool } from "pg";
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const url = process.env.DATABASE_URL ?? "";
+const needsSsl = url.includes("sslmode=");
+const pool = new Pool({
+  connectionString: url.replace(/[?&]sslmode=[^&]*/g, ""),
+  ssl: needsSsl ? { rejectUnauthorized: false } : undefined,
+});
 const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({ adapter });
 


### PR DESCRIPTION
## Summary
- Apply the same SSL fix from `src/lib/prisma.ts` to `prisma/seed.ts` — strip `sslmode=require` from the connection string and pass `ssl: { rejectUnauthorized: false }` explicitly to `pg.Pool`
- Without this, `npx prisma db seed` fails on DigitalOcean managed PostgreSQL because pg v8 treats `sslmode=require` as `verify-full` and rejects the certificate

## Test plan
- [ ] Merge and deploy
- [ ] Run `npx prisma db seed` on the droplet using the doadmin connection string
- [ ] Verify `/resume` loads with seeded data on https://cartergrove.me

🤖 Generated with [Claude Code](https://claude.com/claude-code)