### PR TITLE
Restyle site with warm editorial design system

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -36,7 +36,7 @@ export default async function BlogPostPage({ params }: Props) {
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-12">
-      <Button variant="ghost" size="sm" asChild className="mb-6">
+      <Button variant="ghost" size="sm" asChild className="mb-8">
         <Link href="/blog">
           <ArrowLeft className="mr-2 h-4 w-4" />
           Back to Blog
@@ -44,7 +44,7 @@ export default async function BlogPostPage({ params }: Props) {
       </Button>
 
       <article>
-        <header className="mb-8">
+        <header className="mb-10">
           <time
             dateTime={post.createdAt.toISOString()}
             className="text-sm text-muted-foreground"
@@ -55,10 +55,10 @@ export default async function BlogPostPage({ params }: Props) {
               day: "numeric",
             })}
           </time>
-          <h1 className="mt-2 text-3xl font-bold tracking-tight sm:text-4xl">
+          <h1 className="mt-3 font-serif text-4xl tracking-tight sm:text-5xl">
             {post.title}
           </h1>
-          <div className="mt-3 flex flex-wrap gap-1.5">
+          <div className="mt-4 flex flex-wrap gap-1.5">
             {tags.map((tag) => (
               <Badge key={tag} variant="secondary">
                 {tag}
@@ -68,7 +68,7 @@ export default async function BlogPostPage({ params }: Props) {
         </header>
 
         <div
-          className="prose prose-neutral dark:prose-invert max-w-none"
+          className="prose prose-neutral dark:prose-invert prose-a:text-primary prose-a:decoration-primary/40 max-w-none"
           dangerouslySetInnerHTML={{ __html: html }}
         />
       </article>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -35,7 +35,7 @@ export default async function BlogPage({
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-12">
-      <h1 className="text-3xl font-bold tracking-tight">Blog</h1>
+      <h1 className="font-serif text-4xl tracking-tight">Blog</h1>
       <p className="mt-2 text-muted-foreground">
         Thoughts on software development, tooling, and tech.
       </p>
@@ -63,7 +63,7 @@ export default async function BlogPage({
         ) : (
           filtered.map((post) => (
             <Link key={post.id} href={`/blog/${post.slug}`} className="group block">
-              <Card className="transition-shadow group-hover:shadow-md">
+              <Card className="border-l-2 border-l-transparent transition-all duration-300 group-hover:-translate-y-0.5 group-hover:border-l-primary group-hover:shadow-md">
                 <CardHeader>
                   <div className="flex items-center gap-2 text-xs text-muted-foreground">
                     <time dateTime={post.createdAt.toISOString()}>
@@ -74,7 +74,7 @@ export default async function BlogPage({
                       })}
                     </time>
                   </div>
-                  <CardTitle className="group-hover:text-primary transition-colors">
+                  <CardTitle className="font-serif text-lg transition-colors group-hover:text-primary">
                     {post.title}
                   </CardTitle>
                   <CardDescription>{post.excerpt}</CardDescription>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-outfit);
+  --font-serif: var(--font-instrument-serif);
+  --font-mono: var(--font-jetbrains-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -49,72 +50,72 @@
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --radius: 0.75rem;
+  --background: oklch(0.985 0.003 85);
+  --foreground: oklch(0.165 0.012 65);
+  --card: oklch(0.99 0.002 85);
+  --card-foreground: oklch(0.165 0.012 65);
+  --popover: oklch(0.99 0.002 85);
+  --popover-foreground: oklch(0.165 0.012 65);
+  --primary: oklch(0.40 0.10 155);
+  --primary-foreground: oklch(0.985 0.003 85);
+  --secondary: oklch(0.955 0.006 85);
+  --secondary-foreground: oklch(0.20 0.012 65);
+  --muted: oklch(0.955 0.006 85);
+  --muted-foreground: oklch(0.48 0.012 65);
+  --accent: oklch(0.955 0.008 85);
+  --accent-foreground: oklch(0.20 0.012 65);
+  --destructive: oklch(0.55 0.22 25);
+  --border: oklch(0.91 0.008 80);
+  --input: oklch(0.91 0.008 80);
+  --ring: oklch(0.55 0.06 155);
+  --chart-1: oklch(0.50 0.12 155);
+  --chart-2: oklch(0.65 0.15 75);
+  --chart-3: oklch(0.45 0.08 40);
+  --chart-4: oklch(0.55 0.10 200);
+  --chart-5: oklch(0.60 0.16 30);
+  --sidebar: oklch(0.975 0.003 85);
+  --sidebar-foreground: oklch(0.165 0.012 65);
+  --sidebar-primary: oklch(0.40 0.10 155);
+  --sidebar-primary-foreground: oklch(0.985 0.003 85);
+  --sidebar-accent: oklch(0.955 0.006 85);
+  --sidebar-accent-foreground: oklch(0.20 0.012 65);
+  --sidebar-border: oklch(0.91 0.008 80);
+  --sidebar-ring: oklch(0.55 0.06 155);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.14 0.008 65);
+  --foreground: oklch(0.96 0.004 85);
+  --card: oklch(0.19 0.008 65);
+  --card-foreground: oklch(0.96 0.004 85);
+  --popover: oklch(0.19 0.008 65);
+  --popover-foreground: oklch(0.96 0.004 85);
+  --primary: oklch(0.72 0.10 155);
+  --primary-foreground: oklch(0.14 0.008 65);
+  --secondary: oklch(0.22 0.008 65);
+  --secondary-foreground: oklch(0.96 0.004 85);
+  --muted: oklch(0.22 0.008 65);
+  --muted-foreground: oklch(0.62 0.008 65);
+  --accent: oklch(0.22 0.010 65);
+  --accent-foreground: oklch(0.96 0.004 85);
+  --destructive: oklch(0.70 0.18 20);
+  --border: oklch(0.96 0.004 85 / 10%);
+  --input: oklch(0.96 0.004 85 / 15%);
+  --ring: oklch(0.50 0.06 155);
+  --chart-1: oklch(0.65 0.12 155);
+  --chart-2: oklch(0.70 0.14 75);
+  --chart-3: oklch(0.75 0.12 40);
+  --chart-4: oklch(0.60 0.12 200);
+  --chart-5: oklch(0.65 0.18 30);
+  --sidebar: oklch(0.19 0.008 65);
+  --sidebar-foreground: oklch(0.96 0.004 85);
+  --sidebar-primary: oklch(0.72 0.10 155);
+  --sidebar-primary-foreground: oklch(0.96 0.004 85);
+  --sidebar-accent: oklch(0.22 0.008 65);
+  --sidebar-accent-foreground: oklch(0.96 0.004 85);
+  --sidebar-border: oklch(0.96 0.004 85 / 10%);
+  --sidebar-ring: oklch(0.50 0.06 155);
 }
 
 @layer base {
@@ -124,4 +125,27 @@
   body {
     @apply bg-background text-foreground;
   }
+  ::selection {
+    background: oklch(0.40 0.10 155 / 18%);
+  }
+  .dark ::selection {
+    background: oklch(0.72 0.10 155 / 25%);
+  }
+}
+
+/* Staggered entrance animation */
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.stagger-fade-up {
+  opacity: 0;
+  animation: fade-up 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,25 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Instrument_Serif, Outfit, JetBrains_Mono } from "next/font/google";
 import { Providers } from "@/components/layout/Providers";
 import { Navbar } from "@/components/layout/Navbar";
 import { BannerDisplay } from "@/components/layout/BannerDisplay";
 import { Footer } from "@/components/layout/Footer";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const instrumentSerif = Instrument_Serif({
+  variable: "--font-instrument-serif",
+  weight: "400",
+  style: ["normal", "italic"],
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const outfit = Outfit({
+  variable: "--font-outfit",
+  subsets: ["latin"],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
 });
 
@@ -49,7 +56,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
+        className={`${instrumentSerif.variable} ${outfit.variable} ${jetbrainsMono.variable} font-sans antialiased`}
       >
         <Providers>
           <div className="flex min-h-svh flex-col">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,86 +1,116 @@
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Github, Linkedin, Mail, FileText, FolderOpen, BookOpen } from "lucide-react";
 
 export default function HomePage() {
   return (
-    <div className="mx-auto max-w-5xl px-4 py-16">
+    <div className="mx-auto max-w-5xl px-4 py-20 sm:py-28">
       {/* Hero */}
-      <section className="flex flex-col items-center gap-6 text-center">
-        <div className="flex h-28 w-28 items-center justify-center rounded-full bg-muted text-3xl font-bold text-muted-foreground">
+      <section className="flex flex-col items-center gap-8 text-center">
+        <div
+          className="stagger-fade-up flex h-20 w-20 items-center justify-center rounded-full border border-border/80 font-serif text-2xl text-muted-foreground"
+        >
           CG
         </div>
-        <div className="space-y-2">
-          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+
+        <div className="stagger-fade-up space-y-3" style={{ animationDelay: "0.08s" }}>
+          <h1 className="font-serif text-5xl tracking-tight sm:text-7xl">
             Carter Grove
           </h1>
-          <p className="text-xl text-muted-foreground">Software Engineer</p>
+          <p className="text-xs font-medium uppercase tracking-[0.3em] text-muted-foreground sm:text-sm">
+            Software Engineer
+          </p>
         </div>
-        <p className="max-w-2xl text-muted-foreground">
+
+        <div
+          className="stagger-fade-up h-px w-12 bg-border"
+          style={{ animationDelay: "0.14s" }}
+        />
+
+        <p
+          className="stagger-fade-up max-w-xl text-base leading-relaxed text-muted-foreground"
+          style={{ animationDelay: "0.2s" }}
+        >
           Full-stack developer passionate about building clean, performant software.
           I work with TypeScript, React, Spring Boot, and cloud infrastructure to
           ship products that solve real problems.
         </p>
-        <div className="flex items-center gap-3">
-          <Button variant="outline" size="icon" asChild>
-            <Link
-              href="https://github.com/grovecj"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Github className="h-4 w-4" />
-              <span className="sr-only">GitHub</span>
-            </Link>
-          </Button>
-          <Button variant="outline" size="icon" asChild>
-            <Link
-              href="https://linkedin.com/in/cartergrove"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Linkedin className="h-4 w-4" />
-              <span className="sr-only">LinkedIn</span>
-            </Link>
-          </Button>
-          <Button variant="outline" size="icon" asChild>
-            <Link href="mailto:carter@cartergrove.me">
-              <Mail className="h-4 w-4" />
-              <span className="sr-only">Email</span>
-            </Link>
-          </Button>
+
+        <div
+          className="stagger-fade-up flex items-center gap-5"
+          style={{ animationDelay: "0.28s" }}
+        >
+          <Link
+            href="https://github.com/grovecj"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <Github className="h-4 w-4" />
+            <span>GitHub</span>
+          </Link>
+          <span className="text-border">&middot;</span>
+          <Link
+            href="https://linkedin.com/in/cartergrove"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <Linkedin className="h-4 w-4" />
+            <span>LinkedIn</span>
+          </Link>
+          <span className="text-border">&middot;</span>
+          <Link
+            href="mailto:carter@cartergrove.me"
+            className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <Mail className="h-4 w-4" />
+            <span>Email</span>
+          </Link>
         </div>
       </section>
 
       {/* Quick Links */}
-      <section className="mt-20 grid gap-6 sm:grid-cols-3">
-        <Link href="/resume" className="group">
-          <Card className="transition-shadow group-hover:shadow-md">
+      <section className="mt-24 grid gap-6 sm:grid-cols-3">
+        <Link
+          href="/resume"
+          className="group stagger-fade-up"
+          style={{ animationDelay: "0.36s" }}
+        >
+          <Card className="border-l-2 border-l-transparent transition-all duration-300 group-hover:-translate-y-0.5 group-hover:border-l-primary group-hover:shadow-md">
             <CardHeader>
-              <FileText className="mb-2 h-8 w-8 text-muted-foreground transition-colors group-hover:text-foreground" />
-              <CardTitle>Resume</CardTitle>
+              <FileText className="mb-2 h-6 w-6 text-muted-foreground transition-colors group-hover:text-primary" />
+              <CardTitle className="font-serif text-lg">Resume</CardTitle>
               <CardDescription>
                 Experience, skills, and education — also available as a PDF download.
               </CardDescription>
             </CardHeader>
           </Card>
         </Link>
-        <Link href="/portfolio" className="group">
-          <Card className="transition-shadow group-hover:shadow-md">
+        <Link
+          href="/portfolio"
+          className="group stagger-fade-up"
+          style={{ animationDelay: "0.42s" }}
+        >
+          <Card className="border-l-2 border-l-transparent transition-all duration-300 group-hover:-translate-y-0.5 group-hover:border-l-primary group-hover:shadow-md">
             <CardHeader>
-              <FolderOpen className="mb-2 h-8 w-8 text-muted-foreground transition-colors group-hover:text-foreground" />
-              <CardTitle>Portfolio</CardTitle>
+              <FolderOpen className="mb-2 h-6 w-6 text-muted-foreground transition-colors group-hover:text-primary" />
+              <CardTitle className="font-serif text-lg">Portfolio</CardTitle>
               <CardDescription>
                 Personal projects including Gif Clipper and MLB Stats.
               </CardDescription>
             </CardHeader>
           </Card>
         </Link>
-        <Link href="/blog" className="group">
-          <Card className="transition-shadow group-hover:shadow-md">
+        <Link
+          href="/blog"
+          className="group stagger-fade-up"
+          style={{ animationDelay: "0.48s" }}
+        >
+          <Card className="border-l-2 border-l-transparent transition-all duration-300 group-hover:-translate-y-0.5 group-hover:border-l-primary group-hover:shadow-md">
             <CardHeader>
-              <BookOpen className="mb-2 h-8 w-8 text-muted-foreground transition-colors group-hover:text-foreground" />
-              <CardTitle>Blog</CardTitle>
+              <BookOpen className="mb-2 h-6 w-6 text-muted-foreground transition-colors group-hover:text-primary" />
+              <CardTitle className="font-serif text-lg">Blog</CardTitle>
               <CardDescription>
                 Thoughts on software development, tooling, and tech.
               </CardDescription>

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -2,7 +2,6 @@ import { Metadata } from "next";
 import { prisma } from "@/lib/prisma";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
 import { Download, Mail, MapPin, Globe, Github, Linkedin } from "lucide-react";
 import Link from "next/link";
@@ -49,8 +48,8 @@ export default async function ResumePage() {
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-3xl font-bold">{profile.name}</h1>
-          <p className="text-lg text-muted-foreground">{profile.title}</p>
+          <h1 className="font-serif text-4xl tracking-tight">{profile.name}</h1>
+          <p className="mt-1 text-lg text-muted-foreground">{profile.title}</p>
           <div className="mt-3 flex flex-wrap gap-3 text-sm text-muted-foreground">
             <span className="flex items-center gap-1">
               <MapPin className="h-3.5 w-3.5" /> {profile.location}
@@ -77,19 +76,19 @@ export default async function ResumePage() {
         </Button>
       </div>
 
-      <Separator className="my-8" />
+      <div className="my-10 h-px bg-border/60" />
 
       {/* Summary */}
       <section>
-        <h2 className="mb-3 text-xl font-semibold">Summary</h2>
-        <p className="text-muted-foreground">{profile.summary}</p>
+        <h2 className="mb-3 font-serif text-2xl">Summary</h2>
+        <p className="leading-relaxed text-muted-foreground">{profile.summary}</p>
       </section>
 
-      <Separator className="my-8" />
+      <div className="my-10 h-px bg-border/60" />
 
       {/* Skills */}
       <section>
-        <h2 className="mb-4 text-xl font-semibold">Skills</h2>
+        <h2 className="mb-5 font-serif text-2xl">Skills</h2>
         <div className="grid gap-4 sm:grid-cols-2">
           {skills.map((skill) => (
             <Card key={skill.id}>
@@ -112,12 +111,12 @@ export default async function ResumePage() {
         </div>
       </section>
 
-      <Separator className="my-8" />
+      <div className="my-10 h-px bg-border/60" />
 
       {/* Experience */}
       <section>
-        <h2 className="mb-4 text-xl font-semibold">Experience</h2>
-        <div className="space-y-6">
+        <h2 className="mb-5 font-serif text-2xl">Experience</h2>
+        <div className="space-y-8">
           {experience.map((job) => (
             <div key={job.id}>
               <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
@@ -129,10 +128,10 @@ export default async function ResumePage() {
                   {job.start} &ndash; {job.end}
                 </p>
               </div>
-              <ul className="mt-2 space-y-1">
+              <ul className="mt-3 space-y-1.5">
                 {job.bullets.map((bullet: string, i: number) => (
-                  <li key={i} className="flex gap-2 text-sm text-muted-foreground">
-                    <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50" />
+                  <li key={i} className="flex gap-2 text-sm leading-relaxed text-muted-foreground">
+                    <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-primary/60" />
                     {bullet}
                   </li>
                 ))}
@@ -142,12 +141,12 @@ export default async function ResumePage() {
         </div>
       </section>
 
-      <Separator className="my-8" />
+      <div className="my-10 h-px bg-border/60" />
 
       {/* Education */}
       <section>
-        <h2 className="mb-4 text-xl font-semibold">Education</h2>
-        <div className="space-y-4">
+        <h2 className="mb-5 font-serif text-2xl">Education</h2>
+        <div className="space-y-6">
           {education.map((edu) => (
             <div key={edu.id}>
               <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
@@ -163,10 +162,10 @@ export default async function ResumePage() {
                 </p>
               </div>
               {edu.bullets.length > 0 && (
-                <ul className="mt-2 space-y-1">
+                <ul className="mt-3 space-y-1.5">
                   {edu.bullets.map((bullet: string, i: number) => (
-                    <li key={i} className="flex gap-2 text-sm text-muted-foreground">
-                      <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50" />
+                    <li key={i} className="flex gap-2 text-sm leading-relaxed text-muted-foreground">
+                      <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-primary/60" />
                       {bullet}
                     </li>
                   ))}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,19 +3,20 @@ import { Github, Linkedin, Mail } from "lucide-react";
 
 export function Footer() {
   return (
-    <footer className="border-t">
-      <div className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-4 py-8 sm:flex-row sm:justify-between">
+    <footer className="border-t border-border/60">
+      <div className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-4 py-10 sm:flex-row sm:justify-between">
         <p className="text-sm text-muted-foreground">
-          &copy; {new Date().getFullYear()} Carter Grove. All rights reserved.
+          &copy; {new Date().getFullYear()}{" "}
+          <span className="font-serif">Carter Grove</span>
         </p>
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-5">
           <Link
             href="https://github.com/grovecj"
             target="_blank"
             rel="noopener noreferrer"
             className="text-muted-foreground transition-colors hover:text-foreground"
           >
-            <Github className="h-5 w-5" />
+            <Github className="h-4.5 w-4.5" />
             <span className="sr-only">GitHub</span>
           </Link>
           <Link
@@ -24,14 +25,14 @@ export function Footer() {
             rel="noopener noreferrer"
             className="text-muted-foreground transition-colors hover:text-foreground"
           >
-            <Linkedin className="h-5 w-5" />
+            <Linkedin className="h-4.5 w-4.5" />
             <span className="sr-only">LinkedIn</span>
           </Link>
           <Link
             href="mailto:carter@cartergrove.me"
             className="text-muted-foreground transition-colors hover:text-foreground"
           >
-            <Mail className="h-5 w-5" />
+            <Mail className="h-4.5 w-4.5" />
             <span className="sr-only">Email</span>
           </Link>
         </div>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -23,24 +23,27 @@ export function Navbar() {
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/80 backdrop-blur-sm">
       <nav className="mx-auto flex h-16 max-w-5xl items-center justify-between px-4">
-        <Link href="/" className="text-lg font-semibold tracking-tight">
+        <Link href="/" className="font-serif text-xl tracking-tight">
           Carter Grove
         </Link>
 
         {/* Desktop nav */}
-        <div className="hidden items-center gap-1 md:flex">
+        <div className="hidden items-center gap-6 md:flex">
           {navLinks.map((link) => (
             <Link
               key={link.href}
               href={link.href}
               className={cn(
-                "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
+                "relative py-1 text-sm transition-colors",
                 pathname === link.href
                   ? "text-foreground"
-                  : "text-muted-foreground"
+                  : "text-muted-foreground hover:text-foreground"
               )}
             >
               {link.label}
+              {pathname === link.href && (
+                <span className="absolute -bottom-0.5 left-0 right-0 h-px bg-primary" />
+              )}
             </Link>
           ))}
           <ThemeToggle />
@@ -57,17 +60,17 @@ export function Navbar() {
               </Button>
             </SheetTrigger>
             <SheetContent side="right" className="w-64">
-              <nav className="mt-8 flex flex-col gap-2">
+              <nav className="mt-8 flex flex-col gap-1">
                 {navLinks.map((link) => (
                   <Link
                     key={link.href}
                     href={link.href}
                     onClick={() => setOpen(false)}
                     className={cn(
-                      "rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent",
+                      "rounded-md px-3 py-2.5 text-sm transition-colors",
                       pathname === link.href
-                        ? "text-foreground"
-                        : "text-muted-foreground"
+                        ? "bg-accent text-foreground"
+                        : "text-muted-foreground hover:bg-accent hover:text-foreground"
                     )}
                   >
                     {link.label}

--- a/src/components/portfolio/ProjectSlide.tsx
+++ b/src/components/portfolio/ProjectSlide.tsx
@@ -32,10 +32,10 @@ export function ProjectSlide({
         {/* Text content */}
         <div className="flex flex-col justify-center space-y-6">
           <div>
-            <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">{title}</h2>
+            <h2 className="font-serif text-3xl tracking-tight sm:text-4xl">{title}</h2>
             <p className="mt-2 text-lg text-muted-foreground">{tagline}</p>
           </div>
-          <p className="text-muted-foreground">{description}</p>
+          <p className="leading-relaxed text-muted-foreground">{description}</p>
           <div className="flex flex-wrap gap-2">
             {techStack.map((tech) => (
               <Badge key={tech} variant="outline">
@@ -75,11 +75,11 @@ export function ProjectSlide({
             <img
               src={heroImage}
               alt={`${title} screenshot`}
-              className="rounded-lg border shadow-lg"
+              className="rounded-xl border shadow-lg"
             />
           ) : (
-            <div className="flex aspect-video w-full items-center justify-center rounded-lg border bg-muted">
-              <span className="text-4xl font-bold text-muted-foreground/30">
+            <div className="flex aspect-video w-full items-center justify-center rounded-xl border bg-muted">
+              <span className="font-serif text-4xl text-muted-foreground/30">
                 {title}
               </span>
             </div>

--- a/src/components/portfolio/SubdomainHeader.tsx
+++ b/src/components/portfolio/SubdomainHeader.tsx
@@ -8,7 +8,7 @@ interface SubdomainHeaderProps {
 
 export function SubdomainHeader({ subdomain }: SubdomainHeaderProps) {
   return (
-    <div className="flex items-baseline gap-0 text-2xl font-bold tracking-tight sm:text-3xl">
+    <div className="flex items-baseline gap-0 font-serif text-2xl tracking-tight sm:text-3xl">
       <AnimatePresence mode="wait">
         <motion.span
           key={subdomain}


### PR DESCRIPTION
## Summary
- **Typography**: Replaced Geist with Instrument Serif (headings) + Outfit (body) + JetBrains Mono (code) for a distinctive editorial feel
- **Color palette**: Warm OKLCh "Stone & Sage" palette — cream backgrounds, deep warm charcoal text, sage green primary accent — replacing the generic achromatic grays
- **Animations**: Staggered CSS `fade-up` entrance on the home page hero and navigation cards
- **Component refinements**: Serif logo in navbar with underline active indicators, hover-lift cards with left accent border, sage-tinted bullet points, enhanced prose styling for blog posts

## Files changed
| File | What changed |
|---|---|
| `globals.css` | Full color palette, font variables, selection color, animation keyframes |
| `layout.tsx` | New Google Font imports (Instrument Serif, Outfit, JetBrains Mono) |
| `Navbar.tsx` | Serif logo, underline active link indicator |
| `Footer.tsx` | Serif name, subtler border |
| `page.tsx` (Home) | Staggered fade-up hero, text social links, accent-border cards |
| `resume/page.tsx` | Serif section headings, refined spacing and dividers |
| `blog/page.tsx` | Serif titles, hover-lift cards |
| `blog/[slug]/page.tsx` | Large serif headline, sage prose link colors |
| `SubdomainHeader.tsx` | Serif font for domain display (animation preserved) |
| `ProjectSlide.tsx` | Serif titles, rounded-xl images |

## What's preserved
- Portfolio snap-scroll behavior and dot navigation (untouched)
- SubdomainHeader framer-motion animation (font only change)
- All admin pages and API routes (untouched)
- shadcn/ui component internals (colors flow via CSS variables)

## Test plan
- [ ] Verify home page loads with staggered entrance animation
- [ ] Verify warm cream/sage color palette in both light and dark modes
- [ ] Verify serif headings render on all pages (home, resume, blog, portfolio)
- [ ] Verify portfolio snap scrolling and subdomain animation still work
- [ ] Verify blog post prose renders with sage-colored links
- [ ] Test mobile responsive layout (navbar drawer, card stacking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)