### PR TITLE
Restyle site with Muted Moss design system

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { renderMarkdown } from "@/lib/markdown";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { FadeInView } from "@/components/ui/fade-in-view";
 import { ArrowLeft } from "lucide-react";
 
 export const dynamic = "force-dynamic";
@@ -44,33 +45,37 @@ export default async function BlogPostPage({ params }: Props) {
       </Button>
 
       <article>
-        <header className="mb-8">
-          <time
-            dateTime={post.createdAt.toISOString()}
-            className="text-sm text-muted-foreground"
-          >
-            {post.createdAt.toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
-          </time>
-          <h1 className="mt-2 text-3xl font-bold tracking-tight sm:text-4xl">
-            {post.title}
-          </h1>
-          <div className="mt-3 flex flex-wrap gap-1.5">
-            {tags.map((tag) => (
-              <Badge key={tag} variant="secondary">
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        </header>
+        <FadeInView>
+          <header className="mb-8">
+            <time
+              dateTime={post.createdAt.toISOString()}
+              className="text-sm text-muted-foreground"
+            >
+              {post.createdAt.toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </time>
+            <h1 className="mt-2 text-3xl font-bold tracking-tight sm:text-4xl">
+              {post.title}
+            </h1>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {tags.map((tag) => (
+                <Badge key={tag} variant="secondary">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          </header>
+        </FadeInView>
 
-        <div
-          className="prose prose-neutral dark:prose-invert max-w-none"
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
+        <FadeInView delay={0.15}>
+          <div
+            className="prose prose-neutral dark:prose-invert max-w-none"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </FadeInView>
       </article>
     </div>
   );

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { FadeInView } from "@/components/ui/fade-in-view";
 
 export const dynamic = "force-dynamic";
 
@@ -35,25 +36,29 @@ export default async function BlogPage({
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-12">
-      <h1 className="text-3xl font-bold tracking-tight">Blog</h1>
-      <p className="mt-2 text-muted-foreground">
-        Thoughts on software development, tooling, and tech.
-      </p>
+      <FadeInView>
+        <h1 className="text-3xl font-bold tracking-tight">Blog</h1>
+        <p className="mt-2 text-muted-foreground">
+          Thoughts on software development, tooling, and tech.
+        </p>
+      </FadeInView>
 
       {/* Tag filter */}
       {allTags.length > 0 && (
-        <div className="mt-6 flex flex-wrap gap-2">
-          <Link href="/blog">
-            <Badge variant={!params.tag ? "default" : "outline"}>All</Badge>
-          </Link>
-          {allTags.map((tag) => (
-            <Link key={tag} href={`/blog?tag=${encodeURIComponent(tag)}`}>
-              <Badge variant={params.tag === tag ? "default" : "outline"}>
-                {tag}
-              </Badge>
+        <FadeInView delay={0.1}>
+          <div className="mt-6 flex flex-wrap gap-2">
+            <Link href="/blog">
+              <Badge variant={!params.tag ? "default" : "outline"}>All</Badge>
             </Link>
-          ))}
-        </div>
+            {allTags.map((tag) => (
+              <Link key={tag} href={`/blog?tag=${encodeURIComponent(tag)}`}>
+                <Badge variant={params.tag === tag ? "default" : "outline"}>
+                  {tag}
+                </Badge>
+              </Link>
+            ))}
+          </div>
+        </FadeInView>
       )}
 
       {/* Post list */}
@@ -61,33 +66,35 @@ export default async function BlogPage({
         {filtered.length === 0 ? (
           <p className="text-muted-foreground">No posts yet.</p>
         ) : (
-          filtered.map((post) => (
-            <Link key={post.id} href={`/blog/${post.slug}`} className="group block">
-              <Card className="transition-shadow group-hover:shadow-md">
-                <CardHeader>
-                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                    <time dateTime={post.createdAt.toISOString()}>
-                      {post.createdAt.toLocaleDateString("en-US", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })}
-                    </time>
-                  </div>
-                  <CardTitle className="group-hover:text-primary transition-colors">
-                    {post.title}
-                  </CardTitle>
-                  <CardDescription>{post.excerpt}</CardDescription>
-                  <div className="flex flex-wrap gap-1.5 pt-2">
-                    {post.tags.map((tag: string) => (
-                      <Badge key={tag} variant="secondary" className="text-xs">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                </CardHeader>
-              </Card>
-            </Link>
+          filtered.map((post, i) => (
+            <FadeInView key={post.id} delay={0.1 + i * 0.05}>
+              <Link href={`/blog/${post.slug}`} className="group block">
+                <Card>
+                  <CardHeader>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <time dateTime={post.createdAt.toISOString()}>
+                        {post.createdAt.toLocaleDateString("en-US", {
+                          year: "numeric",
+                          month: "long",
+                          day: "numeric",
+                        })}
+                      </time>
+                    </div>
+                    <CardTitle className="group-hover:text-primary transition-colors">
+                      {post.title}
+                    </CardTitle>
+                    <CardDescription>{post.excerpt}</CardDescription>
+                    <div className="flex flex-wrap gap-1.5 pt-2">
+                      {post.tags.map((tag: string) => (
+                        <Badge key={tag} variant="secondary" className="text-xs">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </CardHeader>
+                </Card>
+              </Link>
+            </FadeInView>
           ))
         )}
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,7 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-inter);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -50,71 +50,71 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --background: oklch(0.948 0.005 105);
+  --foreground: oklch(0.160 0.008 130);
+  --card: oklch(0.970 0.004 105);
+  --card-foreground: oklch(0.160 0.008 130);
+  --popover: oklch(0.970 0.004 105);
+  --popover-foreground: oklch(0.160 0.008 130);
+  --primary: oklch(0.512 0.045 145);
+  --primary-foreground: oklch(0.970 0.004 105);
+  --secondary: oklch(0.900 0.012 120);
+  --secondary-foreground: oklch(0.450 0.045 145);
+  --muted: oklch(0.880 0.010 120);
+  --muted-foreground: oklch(0.476 0.010 130);
+  --accent: oklch(0.920 0.008 130);
+  --accent-foreground: oklch(0.160 0.008 130);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --border: oklch(0.860 0.008 105);
+  --input: oklch(0.860 0.008 105);
+  --ring: oklch(0.512 0.045 145);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: oklch(0.960 0.004 105);
+  --sidebar-foreground: oklch(0.160 0.008 130);
+  --sidebar-primary: oklch(0.512 0.045 145);
+  --sidebar-primary-foreground: oklch(0.970 0.004 105);
+  --sidebar-accent: oklch(0.920 0.008 130);
+  --sidebar-accent-foreground: oklch(0.160 0.008 130);
+  --sidebar-border: oklch(0.860 0.008 105);
+  --sidebar-ring: oklch(0.512 0.045 145);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --background: oklch(0.120 0.005 130);
+  --foreground: oklch(0.770 0.012 115);
+  --card: oklch(0.145 0.008 130);
+  --card-foreground: oklch(0.875 0.010 110);
+  --popover: oklch(0.145 0.008 130);
+  --popover-foreground: oklch(0.875 0.010 110);
+  --primary: oklch(0.650 0.050 145);
+  --primary-foreground: oklch(0.120 0.005 130);
+  --secondary: oklch(0.165 0.020 145);
+  --secondary-foreground: oklch(0.650 0.050 145);
+  --muted: oklch(0.138 0.010 130);
+  --muted-foreground: oklch(0.440 0.015 130);
+  --accent: oklch(0.180 0.010 130);
+  --accent-foreground: oklch(0.875 0.010 110);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --border: oklch(0.180 0.008 130);
+  --input: oklch(0.200 0.008 130);
+  --ring: oklch(0.650 0.050 145);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.140 0.008 130);
+  --sidebar-foreground: oklch(0.875 0.010 110);
+  --sidebar-primary: oklch(0.650 0.050 145);
+  --sidebar-primary-foreground: oklch(0.120 0.005 130);
+  --sidebar-accent: oklch(0.180 0.010 130);
+  --sidebar-accent-foreground: oklch(0.875 0.010 110);
+  --sidebar-border: oklch(0.180 0.008 130);
+  --sidebar-ring: oklch(0.650 0.050 145);
 }
 
 @layer base {
@@ -124,4 +124,26 @@
   body {
     @apply bg-background text-foreground;
   }
+  h1, h2, h3, h4, h5, h6 {
+    letter-spacing: -0.025em;
+  }
+}
+
+/* Gradient utilities */
+.gradient-moss {
+  background: linear-gradient(
+    135deg,
+    oklch(0.512 0.045 145 / 0.04) 0%,
+    transparent 50%,
+    oklch(0.512 0.045 145 / 0.02) 100%
+  );
+}
+
+.dark .gradient-moss {
+  background: linear-gradient(
+    135deg,
+    oklch(0.650 0.050 145 / 0.06) 0%,
+    transparent 50%,
+    oklch(0.650 0.050 145 / 0.03) 100%
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Geist_Mono } from "next/font/google";
 import { Providers } from "@/components/layout/Providers";
 import { Navbar } from "@/components/layout/Navbar";
 import { BannerDisplay } from "@/components/layout/BannerDisplay";
 import { Footer } from "@/components/layout/Footer";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
@@ -49,7 +49,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
+        className={`${inter.variable} ${geistMono.variable} font-sans antialiased`}
       >
         <Providers>
           <div className="flex min-h-svh flex-col">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,92 +1,103 @@
+"use client";
+
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { FadeInView } from "@/components/ui/fade-in-view";
 import { Github, Linkedin, Mail, FileText, FolderOpen, BookOpen } from "lucide-react";
 
 export default function HomePage() {
   return (
     <div className="mx-auto max-w-5xl px-4 py-16">
       {/* Hero */}
-      <section className="flex flex-col items-center gap-6 text-center">
-        <div className="flex h-28 w-28 items-center justify-center rounded-full bg-muted text-3xl font-bold text-muted-foreground">
-          CG
-        </div>
-        <div className="space-y-2">
-          <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
-            Carter Grove
-          </h1>
-          <p className="text-xl text-muted-foreground">Software Engineer</p>
-        </div>
-        <p className="max-w-2xl text-muted-foreground">
-          Full-stack developer passionate about building clean, performant software.
-          I work with TypeScript, React, Spring Boot, and cloud infrastructure to
-          ship products that solve real problems.
-        </p>
-        <div className="flex items-center gap-3">
-          <Button variant="outline" size="icon" asChild>
-            <Link
-              href="https://github.com/grovecj"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Github className="h-4 w-4" />
-              <span className="sr-only">GitHub</span>
-            </Link>
-          </Button>
-          <Button variant="outline" size="icon" asChild>
-            <Link
-              href="https://linkedin.com/in/cartergrove"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Linkedin className="h-4 w-4" />
-              <span className="sr-only">LinkedIn</span>
-            </Link>
-          </Button>
-          <Button variant="outline" size="icon" asChild>
-            <Link href="mailto:carter@cartergrove.me">
-              <Mail className="h-4 w-4" />
-              <span className="sr-only">Email</span>
-            </Link>
-          </Button>
-        </div>
-      </section>
+      <FadeInView>
+        <section className="flex flex-col items-center gap-6 text-center gradient-moss rounded-2xl py-12 -mx-4 px-4">
+          <div className="flex h-28 w-28 items-center justify-center rounded-full bg-muted text-3xl font-bold text-muted-foreground">
+            CG
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+              Carter Grove
+            </h1>
+            <p className="text-xl text-muted-foreground">Software Engineer</p>
+          </div>
+          <p className="max-w-2xl text-muted-foreground">
+            Full-stack developer passionate about building clean, performant software.
+            I work with TypeScript, React, Spring Boot, and cloud infrastructure to
+            ship products that solve real problems.
+          </p>
+          <div className="flex items-center gap-3">
+            <Button variant="outline" size="icon" asChild>
+              <Link
+                href="https://github.com/grovecj"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Github className="h-4 w-4" />
+                <span className="sr-only">GitHub</span>
+              </Link>
+            </Button>
+            <Button variant="outline" size="icon" asChild>
+              <Link
+                href="https://linkedin.com/in/cartergrove"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Linkedin className="h-4 w-4" />
+                <span className="sr-only">LinkedIn</span>
+              </Link>
+            </Button>
+            <Button variant="outline" size="icon" asChild>
+              <Link href="mailto:carter@cartergrove.me">
+                <Mail className="h-4 w-4" />
+                <span className="sr-only">Email</span>
+              </Link>
+            </Button>
+          </div>
+        </section>
+      </FadeInView>
 
       {/* Quick Links */}
       <section className="mt-20 grid gap-6 sm:grid-cols-3">
-        <Link href="/resume" className="group">
-          <Card className="transition-shadow group-hover:shadow-md">
-            <CardHeader>
-              <FileText className="mb-2 h-8 w-8 text-muted-foreground transition-colors group-hover:text-foreground" />
-              <CardTitle>Resume</CardTitle>
-              <CardDescription>
-                Experience, skills, and education — also available as a PDF download.
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        </Link>
-        <Link href="/portfolio" className="group">
-          <Card className="transition-shadow group-hover:shadow-md">
-            <CardHeader>
-              <FolderOpen className="mb-2 h-8 w-8 text-muted-foreground transition-colors group-hover:text-foreground" />
-              <CardTitle>Portfolio</CardTitle>
-              <CardDescription>
-                Personal projects including Gif Clipper and MLB Stats.
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        </Link>
-        <Link href="/blog" className="group">
-          <Card className="transition-shadow group-hover:shadow-md">
-            <CardHeader>
-              <BookOpen className="mb-2 h-8 w-8 text-muted-foreground transition-colors group-hover:text-foreground" />
-              <CardTitle>Blog</CardTitle>
-              <CardDescription>
-                Thoughts on software development, tooling, and tech.
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        </Link>
+        <FadeInView delay={0.1}>
+          <Link href="/resume" className="group block">
+            <Card>
+              <CardHeader>
+                <FileText className="mb-2 h-8 w-8 text-muted-foreground transition-colors group-hover:text-foreground" />
+                <CardTitle>Resume</CardTitle>
+                <CardDescription>
+                  Experience, skills, and education — also available as a PDF download.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+        </FadeInView>
+        <FadeInView delay={0.2}>
+          <Link href="/portfolio" className="group block">
+            <Card>
+              <CardHeader>
+                <FolderOpen className="mb-2 h-8 w-8 text-muted-foreground transition-colors group-hover:text-foreground" />
+                <CardTitle>Portfolio</CardTitle>
+                <CardDescription>
+                  Personal projects including Gif Clipper and MLB Stats.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+        </FadeInView>
+        <FadeInView delay={0.3}>
+          <Link href="/blog" className="group block">
+            <Card>
+              <CardHeader>
+                <BookOpen className="mb-2 h-8 w-8 text-muted-foreground transition-colors group-hover:text-foreground" />
+                <CardTitle>Blog</CardTitle>
+                <CardDescription>
+                  Thoughts on software development, tooling, and tech.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+        </FadeInView>
       </section>
     </div>
   );

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -2,7 +2,8 @@ import { Metadata } from "next";
 import { prisma } from "@/lib/prisma";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
+import { GrowingLine } from "@/components/ui/growing-line";
+import { FadeInView } from "@/components/ui/fade-in-view";
 import { Button } from "@/components/ui/button";
 import { Download, Mail, MapPin, Globe, Github, Linkedin } from "lucide-react";
 import Link from "next/link";
@@ -47,135 +48,145 @@ export default async function ResumePage() {
   return (
     <div className="mx-auto max-w-4xl px-4 py-12">
       {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold">{profile.name}</h1>
-          <p className="text-lg text-muted-foreground">{profile.title}</p>
-          <div className="mt-3 flex flex-wrap gap-3 text-sm text-muted-foreground">
-            <span className="flex items-center gap-1">
-              <MapPin className="h-3.5 w-3.5" /> {profile.location}
-            </span>
-            <span className="flex items-center gap-1">
-              <Mail className="h-3.5 w-3.5" /> {profile.email}
-            </span>
-            <Link href={profile.website} className="flex items-center gap-1 hover:text-foreground">
-              <Globe className="h-3.5 w-3.5" /> {profile.website.replace("https://", "")}
-            </Link>
-            <Link href={`https://github.com/${profile.github}`} className="flex items-center gap-1 hover:text-foreground">
-              <Github className="h-3.5 w-3.5" /> {profile.github}
-            </Link>
-            <Link href={`https://linkedin.com/in/${profile.linkedin}`} className="flex items-center gap-1 hover:text-foreground">
-              <Linkedin className="h-3.5 w-3.5" /> {profile.linkedin}
-            </Link>
+      <FadeInView>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold">{profile.name}</h1>
+            <p className="text-lg text-muted-foreground">{profile.title}</p>
+            <div className="mt-3 flex flex-wrap gap-3 text-sm text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <MapPin className="h-3.5 w-3.5" /> {profile.location}
+              </span>
+              <span className="flex items-center gap-1">
+                <Mail className="h-3.5 w-3.5" /> {profile.email}
+              </span>
+              <Link href={profile.website} className="flex items-center gap-1 hover:text-foreground">
+                <Globe className="h-3.5 w-3.5" /> {profile.website.replace("https://", "")}
+              </Link>
+              <Link href={`https://github.com/${profile.github}`} className="flex items-center gap-1 hover:text-foreground">
+                <Github className="h-3.5 w-3.5" /> {profile.github}
+              </Link>
+              <Link href={`https://linkedin.com/in/${profile.linkedin}`} className="flex items-center gap-1 hover:text-foreground">
+                <Linkedin className="h-3.5 w-3.5" /> {profile.linkedin}
+              </Link>
+            </div>
           </div>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/resume.pdf" target="_blank">
+              <Download className="mr-2 h-4 w-4" />
+              Download PDF
+            </Link>
+          </Button>
         </div>
-        <Button variant="outline" size="sm" asChild>
-          <Link href="/resume.pdf" target="_blank">
-            <Download className="mr-2 h-4 w-4" />
-            Download PDF
-          </Link>
-        </Button>
-      </div>
+      </FadeInView>
 
-      <Separator className="my-8" />
+      <GrowingLine className="my-8" />
 
       {/* Summary */}
-      <section>
-        <h2 className="mb-3 text-xl font-semibold">Summary</h2>
-        <p className="text-muted-foreground">{profile.summary}</p>
-      </section>
+      <FadeInView>
+        <section>
+          <h2 className="mb-3 text-xl font-semibold">Summary</h2>
+          <p className="text-muted-foreground">{profile.summary}</p>
+        </section>
+      </FadeInView>
 
-      <Separator className="my-8" />
+      <GrowingLine className="my-8" />
 
       {/* Skills */}
-      <section>
-        <h2 className="mb-4 text-xl font-semibold">Skills</h2>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {skills.map((skill) => (
-            <Card key={skill.id}>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm font-medium text-muted-foreground">
-                  {skill.category}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="flex flex-wrap gap-1.5">
-                  {skill.items.map((item: string) => (
-                    <Badge key={item} variant="secondary">
-                      {item}
-                    </Badge>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </section>
+      <FadeInView>
+        <section>
+          <h2 className="mb-4 text-xl font-semibold">Skills</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {skills.map((skill) => (
+              <Card key={skill.id}>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm font-medium text-muted-foreground">
+                    {skill.category}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="flex flex-wrap gap-1.5">
+                    {skill.items.map((item: string) => (
+                      <Badge key={item} variant="secondary">
+                        {item}
+                      </Badge>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+      </FadeInView>
 
-      <Separator className="my-8" />
+      <GrowingLine className="my-8" />
 
       {/* Experience */}
-      <section>
-        <h2 className="mb-4 text-xl font-semibold">Experience</h2>
-        <div className="space-y-6">
-          {experience.map((job) => (
-            <div key={job.id}>
-              <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
-                <div>
-                  <h3 className="font-semibold">{job.title}</h3>
-                  <p className="text-sm text-muted-foreground">{job.company} &middot; {job.location}</p>
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  {job.start} &ndash; {job.end}
-                </p>
-              </div>
-              <ul className="mt-2 space-y-1">
-                {job.bullets.map((bullet: string, i: number) => (
-                  <li key={i} className="flex gap-2 text-sm text-muted-foreground">
-                    <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50" />
-                    {bullet}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <Separator className="my-8" />
-
-      {/* Education */}
-      <section>
-        <h2 className="mb-4 text-xl font-semibold">Education</h2>
-        <div className="space-y-4">
-          {education.map((edu) => (
-            <div key={edu.id}>
-              <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
-                <div>
-                  <h3 className="font-semibold">{edu.school}</h3>
+      <FadeInView>
+        <section>
+          <h2 className="mb-4 text-xl font-semibold">Experience</h2>
+          <div className="space-y-6">
+            {experience.map((job) => (
+              <div key={job.id}>
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                  <div>
+                    <h3 className="font-semibold">{job.title}</h3>
+                    <p className="text-sm text-muted-foreground">{job.company} &middot; {job.location}</p>
+                  </div>
                   <p className="text-sm text-muted-foreground">
-                    {edu.degree} in {edu.field}
-                    {edu.gpa && ` — GPA: ${edu.gpa}`}
+                    {job.start} &ndash; {job.end}
                   </p>
                 </div>
-                <p className="text-sm text-muted-foreground">
-                  {edu.start} &ndash; {edu.end}
-                </p>
-              </div>
-              {edu.bullets.length > 0 && (
                 <ul className="mt-2 space-y-1">
-                  {edu.bullets.map((bullet: string, i: number) => (
+                  {job.bullets.map((bullet: string, i: number) => (
                     <li key={i} className="flex gap-2 text-sm text-muted-foreground">
                       <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50" />
                       {bullet}
                     </li>
                   ))}
                 </ul>
-              )}
-            </div>
-          ))}
-        </div>
-      </section>
+              </div>
+            ))}
+          </div>
+        </section>
+      </FadeInView>
+
+      <GrowingLine className="my-8" />
+
+      {/* Education */}
+      <FadeInView>
+        <section>
+          <h2 className="mb-4 text-xl font-semibold">Education</h2>
+          <div className="space-y-4">
+            {education.map((edu) => (
+              <div key={edu.id}>
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                  <div>
+                    <h3 className="font-semibold">{edu.school}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {edu.degree} in {edu.field}
+                      {edu.gpa && ` — GPA: ${edu.gpa}`}
+                    </p>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {edu.start} &ndash; {edu.end}
+                  </p>
+                </div>
+                {edu.bullets.length > 0 && (
+                  <ul className="mt-2 space-y-1">
+                    {edu.bullets.map((bullet: string, i: number) => (
+                      <li key={i} className="flex gap-2 text-sm text-muted-foreground">
+                        <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/50" />
+                        {bullet}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      </FadeInView>
     </div>
   );
 }

--- a/src/components/portfolio/ProjectSlide.tsx
+++ b/src/components/portfolio/ProjectSlide.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { FadeInView } from "@/components/ui/fade-in-view";
 import { ExternalLink, Github } from "lucide-react";
 import Link from "next/link";
 
@@ -28,7 +29,7 @@ export function ProjectSlide({
 }: ProjectSlideProps) {
   return (
     <div className="flex h-full items-center justify-center px-4">
-      <div className="grid w-full max-w-5xl gap-8 lg:grid-cols-2 lg:gap-12">
+      <FadeInView className="grid w-full max-w-5xl gap-8 lg:grid-cols-2 lg:gap-12">
         {/* Text content */}
         <div className="flex flex-col justify-center space-y-6">
           <div>
@@ -85,7 +86,7 @@ export function ProjectSlide({
             </div>
           )}
         </div>
-      </div>
+      </FadeInView>
     </div>
   );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm transition-all duration-300 hover:border-primary/30 hover:shadow-md",
         className
       )}
       {...props}

--- a/src/components/ui/fade-in-view.tsx
+++ b/src/components/ui/fade-in-view.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useRef } from "react";
+import { motion, useInView } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+type Direction = "up" | "down" | "left" | "right" | "none";
+
+interface FadeInViewProps {
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+  direction?: Direction;
+  duration?: number;
+}
+
+const directionOffset: Record<Direction, { x: number; y: number }> = {
+  up: { x: 0, y: 24 },
+  down: { x: 0, y: -24 },
+  left: { x: 24, y: 0 },
+  right: { x: -24, y: 0 },
+  none: { x: 0, y: 0 },
+};
+
+export function FadeInView({
+  children,
+  className,
+  delay = 0,
+  direction = "up",
+  duration = 0.5,
+}: FadeInViewProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-40px" });
+  const offset = directionOffset[direction];
+
+  return (
+    <motion.div
+      ref={ref}
+      className={cn(className)}
+      initial={{ opacity: 0, x: offset.x, y: offset.y }}
+      animate={isInView ? { opacity: 1, x: 0, y: 0 } : undefined}
+      transition={{ duration, delay, ease: "easeOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/ui/growing-line.tsx
+++ b/src/components/ui/growing-line.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface GrowingLineProps {
+  className?: string;
+}
+
+export function GrowingLine({ className }: GrowingLineProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref} className={cn("h-px w-full bg-border/50", className)}>
+      <div
+        className={cn(
+          "h-full bg-border transition-all duration-700 ease-out",
+          visible ? "w-full" : "w-0"
+        )}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace default grayscale shadcn theme with a custom "Muted Moss" palette (desaturated sage green accents, warm grays) in both light and dark modes
- Swap Geist Sans for Inter font with tighter heading letter-spacing
- Add entrance animations (`FadeInView`) and animated section dividers (`GrowingLine`) across all pages
- Add gradient accents on hero section and green-tinted card hover states
- Clean up proof-of-concept preview HTML files

## Test plan
- [ ] Run `npm run dev` and verify light/dark mode toggle works with new sage green palette
- [ ] Scroll through each page to confirm entrance animations trigger once on viewport entry
- [ ] Hover over cards to verify green border tint + shadow transition
- [ ] Check resume page section dividers animate (grow from left) on scroll
- [ ] Verify portfolio snap-scrolling and subdomain display unchanged
- [ ] Confirm Inter font loads (DevTools > Elements > Computed > font-family)
- [ ] Test responsive behavior at mobile/tablet breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)