### PR TITLE
Fix deploy script reliability and add error boundary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,14 +28,15 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           command_timeout: 10m
           script: |
+            set -e
             cd /opt/cartergrove-me
-            cat > .env <<'DOTENV'
-            DATABASE_URL="${{ secrets.DATABASE_URL }}"
-            AUTH_SECRET="${{ secrets.AUTH_SECRET }}"
-            OAUTH_GITHUB_CLIENT_ID="${{ secrets.OAUTH_GITHUB_CLIENT_ID }}"
-            OAUTH_GITHUB_CLIENT_SECRET="${{ secrets.OAUTH_GITHUB_CLIENT_SECRET }}"
-            NEXTAUTH_URL="https://cartergrove.me"
-            DOTENV
+            printf '%s\n' \
+              'DATABASE_URL="${{ secrets.DATABASE_URL }}"' \
+              'AUTH_SECRET="${{ secrets.AUTH_SECRET }}"' \
+              'OAUTH_GITHUB_CLIENT_ID="${{ secrets.OAUTH_GITHUB_CLIENT_ID }}"' \
+              'OAUTH_GITHUB_CLIENT_SECRET="${{ secrets.OAUTH_GITHUB_CLIENT_SECRET }}"' \
+              'NEXTAUTH_URL="https://cartergrove.me"' \
+              > .env
             npm ci
             npx prisma generate
             npx prisma db push --skip-generate

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-16">
+      <h2 className="text-xl font-semibold mb-4">Something went wrong</h2>
+      <pre className="text-sm text-muted-foreground bg-muted rounded-lg p-4 overflow-auto whitespace-pre-wrap">
+        {error.message}
+      </pre>
+      {error.digest && (
+        <p className="mt-2 text-xs text-muted-foreground">Digest: {error.digest}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- All Prisma-dependent pages and API routes (/resume, /blog, /portfolio, /api/resume, /api/blog) return 500 after the Muted Moss merge — the home page (client-only, no Prisma) works fine, confirming this is a **database/deploy issue**, not a redesign issue
- The deploy script's heredoc `.env` writing may have been garbled by the SSH action, and the script lacked `set -e` so any failures during `npm ci`, `prisma generate`, or `build` would silently continue, leaving the server in a broken state
- Replace heredoc with `printf` for reliable `.env` file generation
- Add `set -e` so the deploy aborts on any command failure
- Add `error.tsx` to surface actual error messages in production

## Test plan
- [ ] Merge and verify deploy workflow completes successfully
- [ ] Check /resume, /blog, /portfolio pages load without 500 errors
- [ ] If errors persist, check the browser for the actual error message (now shown by error.tsx instead of generic Next.js error page)
- [ ] Verify home page still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)