### PR TITLE
Fix deploy script reliability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
               > .env
             npm ci
             npx prisma generate
-            npx prisma db push --skip-generate
+            npx prisma db push
             npm run build
             pm2 restart cartergrove-me || pm2 start npm --name cartergrove-me -- start
             pm2 save


### PR DESCRIPTION
## Summary
- Add `set -e` to deploy script so failures abort the build instead of silently continuing
- Replace heredoc with `printf` for `.env` file creation (more reliable across SSH transports)
- Remove `--skip-generate` flag from `prisma db push` (removed in Prisma 7)
- Add `src/app/error.tsx` error boundary to surface server-side errors in production

## Test plan
- [ ] Merge and verify GitHub Actions deploy succeeds
- [ ] Confirm /resume, /portfolio, and /blog pages load on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)